### PR TITLE
Add shared examples to the specs

### DIFF
--- a/spec/omniauth/strategies/amazon-sp-api_spec.rb
+++ b/spec/omniauth/strategies/amazon-sp-api_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
+require 'support/shared_examples'
 
 describe OmniAuth::Strategies::AmazonSpApi do
-  subject do
+  subject(:strategy) do
     strategy = OmniAuth::Strategies::AmazonSpApi.new(nil, nil, options)
     strategy.stub(:session) { {} }
     strategy
@@ -9,48 +10,52 @@ describe OmniAuth::Strategies::AmazonSpApi do
 
   let(:options) { {} }
 
+  include_examples 'an oauth2 strategy'
+
   describe '#client' do
+    subject(:client) { strategy.client }
+
     it 'should have the correct Amazon site' do
-      expect(subject.client.site).to eq(
-        'https://sellingpartnerapi-na.amazon.com'
-      )
+      expect(client.site).to eq'https://sellingpartnerapi-na.amazon.com'
     end
 
     it 'should have the correct authorization url' do
-      expect(subject.client.options[:authorize_url]).to eq(
+      expect(client.options[:authorize_url]).to eq(
         'https://sellercentral.amazon.com/apps/authorize/consent'
       )
     end
 
     it 'should have the correct token url' do
-      expect(subject.client.options[:token_url]).to eq(
+      expect(client.options[:token_url]).to eq(
         'https://api.amazon.com/auth/o2/token'
       )
     end
   end
 
   describe '#callback_path' do
+    subject(:callback_path) { strategy.callback_path }
+
     it 'should have the correct callback path' do
-      expect(subject.callback_path).to eq('/auth/amazon_sp_api/callback')
+      expect(callback_path).to eq '/auth/amazon_sp_api/callback'
     end
   end
 
   describe '#callback_url' do
-    it 'does not include query parameters' do
-      allow(subject).to receive(:full_host).and_return('https://example.com')
-      allow(subject).to receive(:script_name).and_return('/sub_uri')
-      allow(subject).to receive(:query_string).and_return('?foo=bar')
+    subject(:callback_url) { strategy.callback_url }
 
-      expect(subject.callback_url).to eq(
-        'https://example.com/sub_uri/auth/amazon_sp_api/callback'
-      )
+    it 'does not include query parameters' do
+      allow(strategy).to receive(:full_host).and_return('https://example.com')
+      allow(strategy).to receive(:script_name).and_return('/sub_uri')
+      allow(strategy).to receive(:query_string).and_return('?foo=bar')
+
+      expect(callback_url).to eq 'https://example.com/sub_uri/auth/amazon_sp_api/callback'
     end
 
     context 'when a redirect_uri option is informed' do
       let(:options) { { redirect_uri: "https://example.com/auth/amazon_sp_api/callback" } }
 
       it 'returns the redirect_uri' do
-        expect(subject.callback_url).to eq options[:redirect_uri]
+        expect(callback_url).to eq options[:redirect_uri]
       end
     end
   end

--- a/spec/omniauth/strategies/amazon-sp-api_spec.rb
+++ b/spec/omniauth/strategies/amazon-sp-api_spec.rb
@@ -16,7 +16,7 @@ describe OmniAuth::Strategies::AmazonSpApi do
     subject(:client) { strategy.client }
 
     it 'should have the correct Amazon site' do
-      expect(client.site).to eq'https://sellingpartnerapi-na.amazon.com'
+      expect(client.site).to eq 'https://sellingpartnerapi-na.amazon.com'
     end
 
     it 'should have the correct authorization url' do

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -3,41 +3,70 @@
 
 shared_examples 'an oauth2 strategy' do
   describe '#client' do
-    it 'should be initialized with symbolized client_options' do
-      @options = {
-        client_options: {
-          'authorize_url' => 'https://example.com'
+    subject(:client) { strategy.client}
+
+    context  'with client_options informed' do
+      let(:options) do
+        {
+          client_options: { 'authorize_url' => 'https://example.com' }
         }
-      }
-      subject.client.options[:authorize_url].should == 'https://example.com'
+      end
+
+      it 'should be initialized with symbolized client_options' do
+        expect(client.options[:authorize_url]).to eq 'https://example.com'
+      end
     end
   end
 
   describe '#authorize_params' do
-    it 'should include any authorize params passed in the :authorize_params option' do
-      @options = { authorize_params: { foo: 'bar', baz: 'zip' } }
-      subject.authorize_params['foo'].should eq('bar')
-      subject.authorize_params['baz'].should eq('zip')
+    subject(:authorize_params) { strategy.authorize_params}
+
+    context 'with authorized_params option' do
+      let(:options) do
+        { authorize_params: { foo: 'bar', baz: 'zip' } }
+      end
+
+      it 'should include any authorize params passed in the :authorize_params option' do
+        expect(authorize_params['foo']).to eq 'bar'
+        expect(authorize_params['baz']).to eq 'zip'
+      end
     end
 
-    it 'should include top-level options that are marked as :authorize_options' do
-      @options = { authorize_options: %i[scope foo], scope: 'bar', foo: 'baz' }
-      subject.authorize_params['scope'].should eq('bar')
-      subject.authorize_params['foo'].should eq('baz')
+    context 'with top-level options marked as authorized_options' do
+      let(:options) do
+        { authorize_options: %i[scope foo], scope: 'bar', foo: 'baz' }
+      end
+
+      it 'should include top-level options that are marked as :authorize_options' do
+        expect(authorize_params['scope']).to eq 'bar'
+        expect(authorize_params['foo']).to eq 'baz'
+      end
     end
   end
 
   describe '#token_params' do
-    it 'should include any token params passed in the :token_params option' do
-      @options = { token_params: { foo: 'bar', baz: 'zip' } }
-      subject.token_params['foo'].should eq('bar')
-      subject.token_params['baz'].should eq('zip')
+    subject(:token_params) { strategy.token_params}
+
+    context 'with token_params option' do
+      let(:options) do
+        { token_params: { foo: 'bar', baz: 'zip' } }
+      end
+
+      it 'should include any authorize params passed in the :token_params option' do
+        expect(token_params['foo']).to eq 'bar'
+        expect(token_params['baz']).to eq 'zip'
+      end
     end
 
-    it 'should include top-level options that are marked as :token_options' do
-      @options = { token_options: %i[scope foo], scope: 'bar', foo: 'baz' }
-      subject.token_params['scope'].should eq('bar')
-      subject.token_params['foo'].should eq('baz')
+    context 'with top-level options marked as authorized_options' do
+      let(:options) do
+        { token_options: %i[scope foo], scope: 'bar', foo: 'baz' }
+      end
+
+      it 'should include top-level options that are marked as :token_options' do
+        expect(token_params['scope']).to eq 'bar'
+        expect(token_params['foo']).to eq 'baz'
+      end
     end
   end
 end


### PR DESCRIPTION
I noticed that there were some shared examples that weren't being executed. I fixed the syntax and added them to the main specs file.